### PR TITLE
Adds set-timezone! to set the default timezone

### DIFF
--- a/src/clj_time/core.clj
+++ b/src/clj_time/core.clj
@@ -20,7 +20,7 @@
      => (hour (date-time 1986 10 14 22))
      22
 
-   The date-time constructor always returns times in the UTC time zone. If you
+   The date-time constructor always returns times in the default time zone(UTC). If you
    want a time with the specified fields in a different time zone, use
    from-time-zone:
    
@@ -35,7 +35,11 @@
 
    In addition to time-zone-for-offset, you can use the time-zone-for-id and
    default-time-zone functions and the utc Var to constgruct or get DateTimeZone
-   instances.
+   instances,the *default-timezone* Var to get current default timezone.
+
+   You can change the default timezone by set-timezone! :
+
+     =>(set-timezone! (time-zone-for-offset -2))
 
    The functions after? and before? determine the relative position of two
    DateTime instances:
@@ -74,16 +78,23 @@
   (DateTimeZone/UTC)
   "DateTimeZone for UTC.")
 
+(defvar *default-timezone* utc "Default timezone is utc")
+
+(defn set-timezone! [tz]
+  "Set the default timezone to the given one created by time-zone-for-offset or time-zone-for-id"
+  (alter-var-root #'*default-timezone*
+                  (constantly tz)))
+
 (defn now []
-  "Returns a DateTime for the current instant in the UTC time zone."
-  (DateTime. #^DateTimeZone utc))
+  "Returns a DateTime for the current instant in the default time zone(UTC)."
+  (DateTime. #^DateTimeZone *default-timezone*))
 
 (defn epoch []
-  "Returns a DateTime for the begining of the Unix epoch in the UTC time zone."
-  (DateTime. (long 0) #^DateTimeZone utc))
+  "Returns a DateTime for the begining of the Unix epoch in the default time zone(UTC)."
+  (DateTime. (long 0) #^DateTimeZone *default-timezone*))
 
 (defn date-time
-  "Constructs and returns a new DateTime in UTC.
+  "Constructs and returns a new DateTime in default timezone(UTC).
    Specify the year, month of year, day of month, hour of day, minute if hour,
    second of minute, and millisecond of second. Note that month and day are
    1-indexed while hour, second, minute, and millis are 0-indexed.
@@ -103,7 +114,7 @@
    (date-time year month day hour minute second 0))
   ([#^Integer year #^Integer month #^Integer day #^Integer hour
     #^Integer minute #^Integer second #^Integer millis]
-   (DateTime. year month day hour minute second millis #^DateTimeZone utc)))
+   (DateTime. year month day hour minute second millis #^DateTimeZone *default-timezone*)))
 
 (defn year
   "Return the year component of the given DateTime."

--- a/test/clj_time/core_test.clj
+++ b/test/clj_time/core_test.clj
@@ -49,6 +49,14 @@
     (is (= 6 (hour dt2)))
     (is (> (.getMillis dt1) (.getMillis dt2)))))
 
+(deftest test-set-timezone!
+  (let [default-tz  *default-timezone*
+        tz (time-zone-for-offset -2)]
+    (set-timezone! tz)
+    (is (not= *default-timezone* default-tz))
+    (is (= *default-timezone* tz))
+    (set-timezone! utc)))
+
 (deftest test-after?
   (is (after? (date-time 1987) (date-time 1986)))
   (is (not (after? (date-time 1986) (date-time 1987))))


### PR DESCRIPTION
Adds set-timezone! to set the default timezone,default is utc,then now,epoch and date-time will use the configured timezone.
